### PR TITLE
to fix chatInput view layout issu

### DIFF
--- a/SimpleChat/LGSimpleChat/LGSimpleChat.swift
+++ b/SimpleChat/LGSimpleChat/LGSimpleChat.swift
@@ -348,13 +348,20 @@ class LGChatController : UIViewController, UITableViewDelegate, UITableViewDataS
         
         let keyboardAnimationDetail = note.userInfo!
         let duration = keyboardAnimationDetail[UIKeyboardAnimationDurationUserInfoKey] as NSTimeInterval
-        let keyboardFrame = (keyboardAnimationDetail[UIKeyboardFrameEndUserInfoKey] as NSValue).CGRectValue()
+        var keyboardFrame = (keyboardAnimationDetail[UIKeyboardFrameEndUserInfoKey] as NSValue).CGRectValue()
+        if let window = self.view.window {
+            keyboardFrame = window.convertRect(keyboardFrame, toView: self.view)
+        }
         let animationCurve = keyboardAnimationDetail[UIKeyboardAnimationCurveUserInfoKey] as UInt
         
         self.tableView.scrollEnabled = false
         self.tableView.decelerationRate = UIScrollViewDecelerationRateFast
         self.view.layoutIfNeeded()
-        self.bottomChatInputConstraint.constant = -(CGRectGetHeight(UIScreen.mainScreen().bounds) - CGRectGetMinY(keyboardFrame))
+        var chatInputOffset = -(CGRectGetHeight(self.view.bounds) - CGRectGetMinY(keyboardFrame))
+        if chatInputOffset > 0 {
+            chatInputOffset = 0
+        }
+        self.bottomChatInputConstraint.constant = chatInputOffset
         UIView.animateWithDuration(duration, delay: 0.0, options: UIViewAnimationOptions(animationCurve), animations: { () -> Void in
             self.view.layoutIfNeeded()
             self.scrollToBottom()

--- a/SimpleChat/LGSimpleChat/LGSimpleChat.swift
+++ b/SimpleChat/LGSimpleChat/LGSimpleChat.swift
@@ -354,7 +354,7 @@ class LGChatController : UIViewController, UITableViewDelegate, UITableViewDataS
         self.tableView.scrollEnabled = false
         self.tableView.decelerationRate = UIScrollViewDecelerationRateFast
         self.view.layoutIfNeeded()
-        self.bottomChatInputConstraint.constant = -(CGRectGetHeight(self.view.bounds) - CGRectGetMinY(keyboardFrame))
+        self.bottomChatInputConstraint.constant = -(CGRectGetHeight(UIScreen.mainScreen().bounds) - CGRectGetMinY(keyboardFrame))
         UIView.animateWithDuration(duration, delay: 0.0, options: UIViewAnimationOptions(animationCurve), animations: { () -> Void in
             self.view.layoutIfNeeded()
             self.scrollToBottom()


### PR DESCRIPTION
Hello, Logan!
Your SimpleChat is awesome, but I think there is a little problem here: When the navigationBar.translucent  set to be `false`, the chatInput view will miss when keyboard is shown. 
For example, on iPhone 6 with iOS 8 on portrait, the view.bounds.height is 568 when navigationBar.translucent is `true`, but if navigationBar.translucent is `false`, the height will be 504,
so the self.bottomChatInputConstraint.constant here will be different, and chatInput view will under the keyboard, won't be shown.
I tried to fix it on my forked branch, please help check it, thank you so much.